### PR TITLE
#88 removing APT cache to reduce image size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/java_role/tree/develop)
+### Changed
+- *[#88](https://github.com/idealista/java_role/issues/88) Reducing Docker image size cleaning APT cache after package installation* @dortegau
 
 ## [3.4.3](https://github.com/idealista/java_role/tree/4.0.0) (2019-02-08)
 [Full Changelog](https://github.com/idealista/java_role/compare/3.4.3...4.0.0)

--- a/packer/playbook.yml
+++ b/packer/playbook.yml
@@ -5,6 +5,3 @@
   roles:
     - role: ../..
       name: java
-  vars:
-    - ansible_host: default
-    - ansible_connection: docker

--- a/packer/playbook.yml
+++ b/packer/playbook.yml
@@ -5,3 +5,6 @@
   roles:
     - role: ../..
       name: java
+  vars:
+    - ansible_host: default
+    - ansible_connection: docker

--- a/packer/template.json
+++ b/packer/template.json
@@ -1,7 +1,5 @@
 {
     "variables": {
-      "ansible_host": "default",
-      "ansible_connection": "docker",
       "docker_image_base": "{{env `DOCKER_IMAGE_BASE`}}",
       "docker_username": "{{env `DOCKER_USERNAME`}}",
       "docker_password": "{{env `DOCKER_PASSWORD`}}",
@@ -20,8 +18,7 @@
           "-t",
           "--name",
           "{{user `ansible_host`}}",
-          "{{.Image}}",
-          "/bin/bash"
+          "{{.Image}}"
         ],
         "changes" : [
           "LABEL maintainer=\"idealista <labs@idealista.com>\""
@@ -34,7 +31,9 @@
         "inline": [
           "apt-get update",
           "apt-get install python ca-certificates -yq",
-          "mkdir -p /usr/share/man/man1"
+          "mkdir -p /usr/share/man/man1",
+          "rm -rf /var/lib/apt/lists/*",
+          "apt-get clean"
         ]
       },
       {
@@ -43,7 +42,7 @@
         "playbook_file": "{{ template_dir }}/playbook.yml",
         "extra_arguments": [
           "--extra-vars",
-          "ansible_host={{user `ansible_host`}} ansible_connection={{user `ansible_connection`}} java_implementation={{user `jdk_implementation`}} java_oracle_jdk_version={{user `jdk_version`}} java_open_jdk_version={{user `jdk_version`}}"
+          "java_implementation={{user `jdk_implementation`}} java_oracle_jdk_version={{user `jdk_version`}} java_open_jdk_version={{user `jdk_version`}}"
         ]
       }
     ],

--- a/packer/template.json
+++ b/packer/template.json
@@ -1,5 +1,7 @@
 {
     "variables": {
+      "ansible_host": "default",	
+      "ansible_connection": "docker",
       "docker_image_base": "{{env `DOCKER_IMAGE_BASE`}}",
       "docker_username": "{{env `DOCKER_USERNAME`}}",
       "docker_password": "{{env `DOCKER_PASSWORD`}}",
@@ -18,7 +20,8 @@
           "-t",
           "--name",
           "{{user `ansible_host`}}",
-          "{{.Image}}"
+          "{{.Image}}",
+          "/bin/bash"
         ],
         "changes" : [
           "LABEL maintainer=\"idealista <labs@idealista.com>\""
@@ -42,7 +45,7 @@
         "playbook_file": "{{ template_dir }}/playbook.yml",
         "extra_arguments": [
           "--extra-vars",
-          "java_implementation={{user `jdk_implementation`}} java_oracle_jdk_version={{user `jdk_version`}} java_open_jdk_version={{user `jdk_version`}}"
+          "ansible_host={{user `ansible_host`}} ansible_connection={{user `ansible_connection`}} java_implementation={{user `jdk_implementation`}} java_oracle_jdk_version={{user `jdk_version`}} java_open_jdk_version={{user `jdk_version`}}"
         ]
       }
     ],


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Reducing image size removing APT cache after package installation

### Benefits

Improves image size stored in Docker Hub. This will imply that images based on this one will be reduced in size too (ZooKeeper, SolrCloud, Kafka, etc.).

Alternatively, errors like this:

`
E: Could not open file /var/lib/apt/lists/ftp.debian.org_debian_dists_stretch-backports_main_binary-amd64_Packages.diff_Index - open (2: No such file or directory)
`

in derived images will disappear.

### Possible Drawbacks

AFAIK there aren't possible drawbacks

### Applicable Issues

#88 
