### PR TITLE
#86 Fixing Docker Hub image badge url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/java_role/tree/develop)
+### Fixed
+- *[#86](https://github.com/idealista/java_role/issues/86) Fixing Docker Hub image badge url* @dortegau
 
 ## [4.0.0](https://github.com/idealista/java_role/tree/4.0.0) (2019-02-08)
 [Full Changelog](https://github.com/idealista/java_role/compare/3.4.3...4.0.0)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Logo](https://raw.githubusercontent.com/idealista/java_role/master/logo.gif)
 
 [![Build Status](https://travis-ci.org/idealista/java_role.png)](https://travis-ci.org/idealista/java_role)
-[![Docker Hub pulls](https://img.shields.io/docker/pulls/idealista/java-debian-ansible.svg)](https://hub.docker.com/r/idealista/jdk/)
+[![Docker Hub pulls](https://img.shields.io/docker/pulls/idealista/jdk.svg)](https://hub.docker.com/r/idealista/jdk/)
 
 # Java Ansible role
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Fixing Docker Hub image badge pointing to _idealista/jdk_ instead of _idealista/java-debian-ansible_

### Benefits

Showing real number of idealista/jdk repository pulls. Old badge referred to the legacy one.

### Possible Drawbacks

nope

### Applicable Issues

#86 
