### PR TITLE
#63 Solve Ansible Galaxy Warnings

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -5,3 +5,4 @@ exclude_paths:
  - molecule/adoptopenjdk/tests
  - molecule/corretto/tests
  - molecule/default/tests
+ 

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,3 +1,7 @@
 ---
 rules:
   line-length: disable
+exclude_paths:
+ - molecule/adoptopenjdk/tests
+ - molecule/corretto/tests
+ - molecule/default/tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/java_role/tree/develop)
+- *[#63](https://github.com/idealista/java_role/issues/63) Solve Ansible Galaxy Warnings* @vicsufer
 
 ## [6.0.0](https://github.com/idealista/java_role/tree/6.0.0) (2020-08-13)
 [Full Changelog](https://github.com/idealista/java_role/compare/5.2.0...6.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/java_role/tree/develop)
+### Fixed
 - *[#63](https://github.com/idealista/java_role/issues/63) Solve Ansible Galaxy Warnings* @vicsufer
 
 ## [6.0.0](https://github.com/idealista/java_role/tree/6.0.0) (2020-08-13)

--- a/molecule/adoptopenjdk/verify.yml
+++ b/molecule/adoptopenjdk/verify.yml
@@ -39,12 +39,14 @@
     - name: Register test files
       shell: "ls {{ goss_test_directory }}/test_*.yml"
       register: test_files
+      changed_when: false
 
     - name: Execute Goss tests
       command: "goss -g {{ item }} validate --format {{ goss_format }}"
       register: test_results
       with_items: "{{ test_files.stdout_lines }}"
       ignore_errors: true
+      changed_when: false
 
     - name: Display details about the goss results
       debug:

--- a/molecule/corretto/verify.yml
+++ b/molecule/corretto/verify.yml
@@ -39,12 +39,14 @@
     - name: Register test files
       shell: "ls {{ goss_test_directory }}/test_*.yml"
       register: test_files
+      changed_when: false
 
     - name: Execute Goss tests
       command: "goss -g {{ item }} validate --format {{ goss_format }}"
       register: test_results
       with_items: "{{ test_files.stdout_lines }}"
       ignore_errors: true
+      changed_when: false
 
     - name: Display details about the goss results
       debug:

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -61,12 +61,14 @@
     - name: Register test files
       shell: "ls {{ goss_test_directory }}/test_*.yml"
       register: test_files
+      changed_when: false
 
     - name: Execute Goss tests
       command: "goss -g {{ item }} validate --format {{ goss_format }}"
       register: test_results
       with_items: "{{ test_files.stdout_lines }}"
       ignore_errors: true
+      changed_when: false
 
     - name: Display details about the goss results
       debug:


### PR DESCRIPTION
### Requirements

*  Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

- Exclude test directories from being linted.
- Explicitly `changed_when` to `false` whenever a task runs a command that does not change the host state



### Benefits
Improve ansible-galaxy quality score for this role.

### Possible Drawbacks

None AFAIK

### Applicable Issues
#63 
