### PR TITLE
Hotfix release 6.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,22 +18,22 @@ env:
   - secure: jnMLyXO4BXHo5OWGDsgtTnKBoiV+EG5Qd7w+a0RfkJu/SeqW/pm7NOnGqWDxKUdf9UREtKvCO26ZdciC2DwmjOVsSH5KVnvS7fr2QvPalHNJhi8IHkSOi5BP4DUIFlJowBKCGMTftNUJCiZq5tq8GnnwR9eaQg0WqhqcSmRA/dIyN4MycayGhqt/+9gaTiOaiKrun7esAUnizszXOj8P0QBLxjAiXIfDmwUfe6z7vHRaf96L/T5tpDcRd00jxm+QYlsN8zIxYK5CguPwl/ip2jRAdkq2KA8MT5tL7qaqkqAKzzaetHKbSigzuzER8Wua5Qc3JZajI9YMayvJSrow3fXDmGg+T4XYJgRe87HtIO3IwHclvtfsYgrD1kYhLm+jo2czm8uQIKdQZqVkZ8lJxhV24yZ76Xa0ysEzmHXbV2HHmNYud2Kuh8CYPA+M9yB8icwoc58IqOOfj7/N8Siv5oypSuWmEHZdkhPVkPBY4Qq7aDMGy4/Uzy+yu4V++6oJrXZMAKKlDnuMayZylEaN+CLjZnDFDjusYDkTZRoNo1Bt5EiEb0AZQ19caVW0kRD0rseRa/Af/DYJswTo6AyXs4Tk2B4Mm/0XYGhku4QKZw6In3/FxTHxF16y9GZMv1T/0xRXpkmFYYHJE/4vhhsN0shTRNe+9b+tc/zvd5a3/3g=
   jobs:
   # openjdk
-  - DOCKER_IMAGE_BASE=debian:stretch-slim JDK_VENDOR=openjdk DOCKER_TAG_TO_PUBLISH=8-stretch-openjdk-headless
-  - DOCKER_IMAGE_BASE=debian:stretch-slim JDK_VENDOR=openjdk JDK_MAJOR=8 JDK_VERSION=8u265-b01-0+deb9u1 DOCKER_TAG_TO_PUBLISH=8u265-stretch-openjdk-headless
-  - DOCKER_IMAGE_BASE=debian:stretch-slim JDK_VENDOR=openjdk JDK_MAJOR=11 JDK_VERSION=11.0.6+10-1~bpo9+1 DOCKER_TAG_TO_PUBLISH=11.0.6-stretch-openjdk-headless
-  - DOCKER_IMAGE_BASE=debian:buster-slim JDK_VENDOR=openjdk DOCKER_TAG_TO_PUBLISH=11-buster-openjdk-headless
-  - DOCKER_IMAGE_BASE=debian:buster-slim JDK_VENDOR=openjdk JDK_MAJOR=11 JDK_VERSION=11.0.8+10-1~deb10u1 DOCKER_TAG_TO_PUBLISH=11.0.8-buster-openjdk-headless
-  - DOCKER_IMAGE_BASE=amd64/ubuntu:xenial JDK_VENDOR=openjdk DOCKER_TAG_TO_PUBLISH=9-xenial-openjdk-headless
-  - DOCKER_IMAGE_BASE=amd64/ubuntu:xenial JDK_VENDOR=openjdk JDK_MAJOR=8 JDK_VERSION=8u265-b01-0ubuntu2~16.04 DOCKER_TAG_TO_PUBLISH=8u265-xenial-openjdk-headless
-  - DOCKER_IMAGE_BASE=amd64/ubuntu:xenial JDK_VENDOR=openjdk JDK_MAJOR=9 JDK_VERSION=9~b114-0ubuntu1 DOCKER_TAG_TO_PUBLISH=9b114-xenial-openjdk-headless
-  - DOCKER_IMAGE_BASE=amd64/ubuntu:bionic JDK_VENDOR=openjdk DOCKER_TAG_TO_PUBLISH=11-bionic-openjdk-headless
-  - DOCKER_IMAGE_BASE=amd64/ubuntu:bionic JDK_VENDOR=openjdk JDK_MAJOR=11 JDK_VERSION=11.0.8+10-0ubuntu1~18.04.1 DOCKER_TAG_TO_PUBLISH=11.0.8-bionic-openjdk-headless
-  - DOCKER_IMAGE_BASE=amd64/ubuntu:bionic JDK_VENDOR=openjdk JDK_MAJOR=8 JDK_VERSION=8u265-b01-0ubuntu2~18.04 DOCKER_TAG_TO_PUBLISH=8u265-bionic-openjdk-headless
-  - DOCKER_IMAGE_BASE=amd64/ubuntu:focal JDK_VENDOR=openjdk DOCKER_TAG_TO_PUBLISH=14-focal-openjdk-headless
-  - DOCKER_IMAGE_BASE=amd64/ubuntu:focal JDK_VENDOR=openjdk JDK_MAJOR=14 JDK_VERSION=14.0.1+7-1ubuntu1 DOCKER_TAG_TO_PUBLISH=14.0.1-focal-openjdk-headless
-  - DOCKER_IMAGE_BASE=amd64/ubuntu:focal JDK_VENDOR=openjdk JDK_MAJOR=8 JDK_VERSION=8u265-b01-0ubuntu2~20.04 DOCKER_TAG_TO_PUBLISH=8u265-focal-openjdk-headless
-  - DOCKER_IMAGE_BASE=centos:7 JDK_VENDOR=openjdk JDK_MAJOR=11 JDK_VERSION=11.0.8.10 DOCKER_TAG_TO_PUBLISH=11.0.8.10-centos7-openjdk-headless
-  - DOCKER_IMAGE_BASE=centos:8 JDK_VENDOR=openjdk JDK_MAJOR=11 JDK_VERSION=11.0.8.10 DOCKER_TAG_TO_PUBLISH=11.0.8.10-centos8-openjdk-headless
+  - DOCKER_IMAGE_BASE=debian:stretch-slim DOCKER_TAG_TO_PUBLISH=8-stretch-openjdk-headless
+  - DOCKER_IMAGE_BASE=debian:stretch-slim JDK_MAJOR=8 JDK_VERSION=8u265-b01-0+deb9u1 DOCKER_TAG_TO_PUBLISH=8u265-stretch-openjdk-headless
+  - DOCKER_IMAGE_BASE=debian:stretch-slim JDK_MAJOR=11 JDK_VERSION=11.0.6+10-1~bpo9+1 DOCKER_TAG_TO_PUBLISH=11.0.6-stretch-openjdk-headless
+  - DOCKER_IMAGE_BASE=debian:buster-slim DOCKER_TAG_TO_PUBLISH=11-buster-openjdk-headless
+  - DOCKER_IMAGE_BASE=debian:buster-slim JDK_MAJOR=11 JDK_VERSION=11.0.8+10-1~deb10u1 DOCKER_TAG_TO_PUBLISH=11.0.8-buster-openjdk-headless
+  - DOCKER_IMAGE_BASE=amd64/ubuntu:xenial DOCKER_TAG_TO_PUBLISH=9-xenial-openjdk-headless
+  - DOCKER_IMAGE_BASE=amd64/ubuntu:xenial JDK_MAJOR=8 JDK_VERSION=8u265-b01-0ubuntu2~16.04 DOCKER_TAG_TO_PUBLISH=8u265-xenial-openjdk-headless
+  - DOCKER_IMAGE_BASE=amd64/ubuntu:xenial JDK_MAJOR=9 JDK_VERSION=9~b114-0ubuntu1 DOCKER_TAG_TO_PUBLISH=9b114-xenial-openjdk-headless
+  - DOCKER_IMAGE_BASE=amd64/ubuntu:bionic DOCKER_TAG_TO_PUBLISH=11-bionic-openjdk-headless
+  - DOCKER_IMAGE_BASE=amd64/ubuntu:bionic JDK_MAJOR=11 JDK_VERSION=11.0.8+10-0ubuntu1~18.04.1 DOCKER_TAG_TO_PUBLISH=11.0.8-bionic-openjdk-headless
+  - DOCKER_IMAGE_BASE=amd64/ubuntu:bionic JDK_MAJOR=8 JDK_VERSION=8u265-b01-0ubuntu2~18.04 DOCKER_TAG_TO_PUBLISH=8u265-bionic-openjdk-headless
+  - DOCKER_IMAGE_BASE=amd64/ubuntu:focal DOCKER_TAG_TO_PUBLISH=14-focal-openjdk-headless
+  - DOCKER_IMAGE_BASE=amd64/ubuntu:focal JDK_MAJOR=14 JDK_VERSION=14.0.1+7-1ubuntu1 DOCKER_TAG_TO_PUBLISH=14.0.1-focal-openjdk-headless
+  - DOCKER_IMAGE_BASE=amd64/ubuntu:focal JDK_MAJOR=8 JDK_VERSION=8u265-b01-0ubuntu2~20.04 DOCKER_TAG_TO_PUBLISH=8u265-focal-openjdk-headless
+  - DOCKER_IMAGE_BASE=centos:7 JDK_MAJOR=11 JDK_VERSION=11.0.8.10 DOCKER_TAG_TO_PUBLISH=11.0.8.10-centos7-openjdk-headless
+  - DOCKER_IMAGE_BASE=centos:8 JDK_MAJOR=11 JDK_VERSION=11.0.8.10 DOCKER_TAG_TO_PUBLISH=11.0.8.10-centos8-openjdk-headless
   # adoptopenjdk
   - DOCKER_IMAGE_BASE=debian:buster-slim JDK_VENDOR=adoptopenjdk JDK_MAJOR=8 JDK_VERSION=8u265-b01-3 DOCKER_TAG_TO_PUBLISH=8u265-buster-adoptopenjdk-headless
   - DOCKER_IMAGE_BASE=centos:8 JDK_VENDOR=adoptopenjdk JDK_MAJOR=8 JDK_VERSION=8u265_b01 DOCKER_TAG_TO_PUBLISH=8u265-centos8-adoptopenjdk-headless
@@ -47,7 +47,7 @@ notifications:
   - https://galaxy.ansible.com/api/v1/notifications/
 deploy:
   provider: script
-  script: packer build packer/template.json
+  script: JDK_VENDOR=${JDK_VENDOR:-openjdk} packer build packer/template.json
   on:
     branch: master
     tags: true


### PR DESCRIPTION
### Requirements

JDK_VENDOR environment variable must be set in travis jobs due to packer setting de variable to an empty string when environment variable is not defined, this result in ansible using empty string instead of using the defaults/main.yml values.
### Description of the Change

### Benefits
N/A

### Possible Drawbacks
N/A

### Applicable Issues
N/A
